### PR TITLE
use eyra + call out need for nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,18 +15,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "c-gull"
 version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99a4d93dc9646a9a29804d11c0f93e7450b392ad8d4e30e6acbd33487eb61364"
 dependencies = [
- "c-scape",
+ "c-scape 0.8.13",
  "errno",
  "libc",
  "log",
  "printf-compat",
- "rustix",
+ "rustix 0.37.19",
  "sync-resolve",
+ "tz-rs",
+]
+
+[[package]]
+name = "c-gull"
+version = "0.15.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08158cb0a0829ee7c908536544b2b39cd1539b0b22c3ddeb8d4b40a1ef2bb4f1"
+dependencies = [
+ "c-scape 0.15.13",
+ "errno",
+ "libc",
+ "printf-compat",
+ "rustix 0.38.21",
  "tz-rs",
 ]
 
@@ -40,13 +60,35 @@ dependencies = [
  "libc",
  "libm",
  "log",
- "memoffset",
- "origin",
+ "memoffset 0.8.0",
+ "origin 0.8.13",
  "rand",
  "rand_core",
  "rand_pcg",
  "realpath-ext",
- "rustix",
+ "rustix 0.37.19",
+]
+
+[[package]]
+name = "c-scape"
+version = "0.15.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff425aea074f3a5fdee3f0e2c5e5a6e9239b95762c060dfbda0449b63c0a70fa"
+dependencies = [
+ "errno",
+ "libc",
+ "libm",
+ "memoffset 0.9.0",
+ "origin 0.14.0",
+ "rand",
+ "rand_core",
+ "rand_pcg",
+ "realpath-ext",
+ "rustix 0.38.21",
+ "rustix-dlmalloc",
+ "rustix-futex-sync",
+ "rustix-openpty",
+ "unwinding 0.2.0",
 ]
 
 [[package]]
@@ -106,23 +148,21 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "eyra"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "70f0bb9a335ad4906fbae0045e458377b0080ae0eeedced1b216265424f6c36b"
 dependencies = [
- "cc",
- "libc",
+ "c-gull 0.15.13",
 ]
 
 [[package]]
@@ -187,9 +227,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libm"
@@ -204,10 +244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
+name = "linux-raw-sys"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -244,15 +290,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mustang"
 version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c10e8df8836e677762c806c00194c756bab08566b3a730094b0917fea660f7"
 dependencies = [
- "c-gull",
+ "c-gull 0.8.13",
  "dlmalloc",
- "origin",
- "unwinding",
+ "origin 0.8.13",
+ "unwinding 0.1.6",
 ]
 
 [[package]]
@@ -261,7 +316,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if 0.1.10",
  "libc",
@@ -279,12 +334,26 @@ version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a06d5fcfd4d45cf3dc0257c248f3d5872e479fb13bf1308ebad9da84b707ae"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.7",
  "lock_api",
- "memoffset",
- "rustix",
+ "memoffset 0.8.0",
+ "rustix 0.37.19",
+]
+
+[[package]]
+name = "origin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ec3dcf976d221ecd72070fc76a8a8bc7de6cef95559b7be77579697408c5e8"
+dependencies = [
+ "bitflags 2.4.1",
+ "linux-raw-sys 0.4.10",
+ "memoffset 0.9.0",
+ "rustix 0.38.21",
+ "rustix-futex-sync",
+ "unwinding 0.2.0",
 ]
 
 [[package]]
@@ -309,7 +378,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b002af28ffe3d3d67202ae717810a28125a494d5396debc43de01ee136ac404"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cstr_core",
  "cty",
  "itertools",
@@ -360,7 +429,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692f72862a0d532b44a0f4965fb10f17e7659eaedf24d2ce3c989ca778bd092f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "libc",
 ]
@@ -369,6 +438,7 @@ dependencies = [
 name = "rush"
 version = "0.1.0"
 dependencies = [
+ "eyra",
  "mustang",
  "nix",
  "os_pipe",
@@ -380,14 +450,60 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.7",
  "once_cell",
  "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "itoa",
+ "libc",
+ "linux-raw-sys 0.4.10",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix-dlmalloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730c0a5fbe9885450abcfca57da8c5d5a886492d01aa1a78b782fc5ddb2c0931"
+dependencies = [
+ "rustix 0.38.21",
+ "rustix-futex-sync",
+]
+
+[[package]]
+name = "rustix-futex-sync"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebec5b686394f118236986b64350c06de4504a4dbe32f4e2e96c9f8adc15390"
+dependencies = [
+ "lock_api",
+ "rustix 0.38.21",
+]
+
+[[package]]
+name = "rustix-openpty"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c3aad9fc1424eb82c88087789a7d938e1829724f3e4043163baf0d13cfc12"
+dependencies = [
+ "errno",
+ "libc",
+ "rustix 0.38.21",
 ]
 
 [[package]]
@@ -451,6 +567,16 @@ name = "unwinding"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5145b2053e3c94447eff8fd715c4ec6fde78a726da864e357125f6f71f74880"
+dependencies = [
+ "gimli",
+ "libc",
+]
+
+[[package]]
+name = "unwinding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee215fc0991fb587275819562685254302112d0b7c8d25e635655526c0ecdc6"
 dependencies = [
  "gimli",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 mustang = "0.8.4"
 os_pipe = "0.9.2"
 nix = "0.18.0"
+std = { version = "0.16.2", package = "eyra" }
 
 [profile.release-small]
 inherits = "release"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-nostartfiles");
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Fails to build with:

```
error[E0425]: cannot find function `statx` in crate `libc`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/fs/mod.rs:46:17
    |
46  |     libc!(libc::statx(dirfd_, path, flags, mask, checked_cast!(stat_)));
    |                 ^^^^^
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/mod.rs:747:5
    |
747 |     pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
    |     ----------------------------------------------------------- similarly named function `stat` defined here
    |
help: a function with a similar name exists
    |
46  |     libc!(libc::stat(dirfd_, path, flags, mask, checked_cast!(stat_)));
    |                 ~~~~
help: consider importing one of these items
    |
28  + use crate::fs::statx;
    |
28  + use rustix::fs::statx;
    |
help: if you import `statx`, refer to it directly
    |
46  -     libc!(libc::statx(dirfd_, path, flags, mask, checked_cast!(stat_)));
46  +     libc!(statx(dirfd_, path, flags, mask, checked_cast!(stat_)));
    |

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:17:65
   |
17 |     destructors: [Option<unsafe extern "C" fn(_: *mut c_void)>; PTHREAD_KEYS_MAX as usize],
   |                                                                 ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:17:65
   |
17 |     destructors: [Option<unsafe extern "C" fn(_: *mut c_void)>; PTHREAD_KEYS_MAX as usize],
   |                                                                 ^^^^^^^^^^^^^^^^ not found in this scope
   |
help: you might be missing a const parameter
   |
15 | struct KeyData<const PTHREAD_KEYS_MAX: /* Type */> {
   |               ++++++++++++++++++++++++++++++++++++

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:37:25
   |
37 |     destructors: [None; PTHREAD_KEYS_MAX as usize],
   |                         ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:40:28
   |
40 | static EPOCHS: [AtomicU32; PTHREAD_KEYS_MAX as usize] =
   |                            ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:41:35
   |
41 |     [const { AtomicU32::new(0) }; PTHREAD_KEYS_MAX as usize];
   |                                   ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:46:39
   |
46 | static VALUES: [Cell<ValueWithEpoch>; PTHREAD_KEYS_MAX as usize] =
   |                                       ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:47:50
   |
47 |     [const { Cell::new(ValueWithEpoch::new()) }; PTHREAD_KEYS_MAX as usize];
   |                                                  ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:80:29
   |
80 |                 for i in 0..PTHREAD_KEYS_MAX {
   |                             ^^^^^^^^^^^^^^^^ not found in this scope
   |
help: you might have meant to write `.` instead of `..`
   |
80 -                 for i in 0..PTHREAD_KEYS_MAX {
80 +                 for i in 0.PTHREAD_KEYS_MAX {
   |

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:138:19
    |
138 |     if next_key < PTHREAD_KEYS_MAX {
    |                   ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PTHREAD_KEYS_MAX` in this scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:159:24
    |
159 |         if next_key >= PTHREAD_KEYS_MAX {
    |                        ^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `statx` in crate `libc`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process_.rs:152:26
    |
152 |             return libc::statx as *mut c_void;
    |                          ^^^^^
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/mod.rs:747:5
    |
747 |     pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
    |     ----------------------------------------------------------- similarly named function `stat` defined here
    |
help: a function with a similar name exists
    |
152 |             return libc::stat as *mut c_void;
    |                          ~~~~
help: consider importing this function
    |
1   + use rustix::fs::statx;
    |
help: if you import `statx`, refer to it directly
    |
152 -             return libc::statx as *mut c_void;
152 +             return statx as *mut c_void;
    |

error[E0425]: cannot find function `getentropy` in crate `libc`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/rand_.rs:32:17
   |
32 |     libc!(libc::getentropy(buf, buflen));
   |                 ^^^^^^^^^^ not found in `libc`
   |
help: consider importing this function
   |
1  + use crate::rand_::getentropy;
   |
help: if you import `getentropy`, refer to it directly
   |
32 -     libc!(libc::getentropy(buf, buflen));
32 +     libc!(getentropy(buf, buflen));
   |

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/io/mod.rs:70:35
    |
70  |             libc!(libc::ioctl(fd, libc::FICLONE, src_fd));
    |                   -----------     ^^^^^^^^^^^^^ expected `i32`, found `u64`
    |                   |
    |                   arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:736:12
    |
736 |     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
    |            ^^^^^
help: you can convert a `u64` to an `i32` and panic if the converted value doesn't fit
    |
70  |             libc!(libc::ioctl(fd, libc::FICLONE.try_into().unwrap(), src_fd));
    |                                                ++++++++++++++++++++

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:8:29
    |
8   |     libc!(libc::getpriority(which, who));
    |           ----------------- ^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:739:12
    |
739 |     pub fn getpriority(which: ::c_int, who: ::id_t) -> ::c_int;
    |            ^^^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
8   |     libc!(libc::getpriority(which.try_into().unwrap(), who));
    |                                  ++++++++++++++++++++

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:11:9
   |
10 |     let result = match which {
   |                        ----- this expression has type `u32`
11 |         libc::PRIO_PROCESS => rustix::process::getpriority_process(Pid::from_raw(who as pid_t)),
   |         ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:12:9
   |
10 |     let result = match which {
   |                        ----- this expression has type `u32`
11 |         libc::PRIO_PROCESS => rustix::process::getpriority_process(Pid::from_raw(who as pid_t)),
12 |         libc::PRIO_PGRP => rustix::process::getpriority_pgrp(Pid::from_raw(who as pid_t)),
   |         ^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:13:9
   |
10 |     let result = match which {
   |                        ----- this expression has type `u32`
...
13 |         libc::PRIO_USER => rustix::process::getpriority_user(Uid::from_raw(who)),
   |         ^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:28:29
    |
28  |     libc!(libc::setpriority(which, who, prio));
    |           ----------------- ^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:740:12
    |
740 |     pub fn setpriority(which: ::c_int, who: ::id_t, prio: ::c_int) -> ::c_int;
    |            ^^^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
28  |     libc!(libc::setpriority(which.try_into().unwrap(), who, prio));
    |                                  ++++++++++++++++++++

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:31:9
   |
30 |     let result = match which {
   |                        ----- this expression has type `u32`
31 |         libc::PRIO_PROCESS => {
   |         ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:34:9
   |
30 |     let result = match which {
   |                        ----- this expression has type `u32`
...
34 |         libc::PRIO_PGRP => rustix::process::setpriority_pgrp(Pid::from_raw(who as pid_t), prio),
   |         ^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/priority.rs:35:9
   |
30 |     let result = match which {
   |                        ----- this expression has type `u32`
...
35 |         libc::PRIO_USER => rustix::process::setpriority_user(Uid::from_raw(who), prio),
   |         ^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:7:27
    |
7   |     libc!(libc::getrlimit(resource, old_limit));
    |           --------------- ^^^^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:728:12
    |
728 |     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
    |            ^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
7   |     libc!(libc::getrlimit(resource.try_into().unwrap(), old_limit));
    |                                   ++++++++++++++++++++

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:22:29
   |
22 |     libc!(libc::getrlimit64(resource, old_limit));
   |           ----------------- ^^^^^^^^ expected `i32`, found `u32`
   |           |
   |           arguments to this function are incorrect
   |
note: function defined here
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/lfs64.rs:85:26
   |
85 | pub unsafe extern "C" fn getrlimit64(resource: ::c_int, rlim: *mut ::rlimit64) -> ::c_int {
   |                          ^^^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
   |
22 |     libc!(libc::getrlimit64(resource.try_into().unwrap(), old_limit));
   |                                     ++++++++++++++++++++

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:37:27
    |
37  |     libc!(libc::setrlimit(resource, new_limit));
    |           --------------- ^^^^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:729:12
    |
729 |     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
    |            ^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
37  |     libc!(libc::setrlimit(resource.try_into().unwrap(), new_limit));
    |                                   ++++++++++++++++++++

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:52:29
    |
52  |     libc!(libc::setrlimit64(resource, new_limit));
    |           ----------------- ^^^^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/lfs64.rs:214:26
    |
214 | pub unsafe extern "C" fn setrlimit64(resource: ::c_int, rlim: *const ::rlimit64) -> ::c_int {
    |                          ^^^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
52  |     libc!(libc::setrlimit64(resource.try_into().unwrap(), new_limit));
    |                                     ++++++++++++++++++++

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:72:30
    |
72  |     libc!(libc::prlimit(pid, resource, new_limit, old_limit));
    |           -------------      ^^^^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:730:12
    |
730 |     pub fn prlimit(
    |            ^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
72  |     libc!(libc::prlimit(pid, resource.try_into().unwrap(), new_limit, old_limit));
    |                                      ++++++++++++++++++++

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:98:32
    |
98  |     libc!(libc::prlimit64(pid, resource, new_limit, old_limit));
    |           ---------------      ^^^^^^^^ expected `i32`, found `u32`
    |           |
    |           arguments to this function are incorrect
    |
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/lfs64.rs:160:26
    |
160 | pub unsafe extern "C" fn prlimit64(
    |                          ^^^^^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
98  |     libc!(libc::prlimit64(pid, resource.try_into().unwrap(), new_limit, old_limit));
    |                                        ++++++++++++++++++++

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:119:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
119 |         libc::RLIMIT_CPU => Resource::Cpu,
    |         ^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:120:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
119 |         libc::RLIMIT_CPU => Resource::Cpu,
120 |         libc::RLIMIT_FSIZE => Resource::Fsize,
    |         ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:121:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
121 |         libc::RLIMIT_DATA => Resource::Data,
    |         ^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:122:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
122 |         libc::RLIMIT_STACK => Resource::Stack,
    |         ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:123:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
123 |         libc::RLIMIT_CORE => Resource::Core,
    |         ^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:124:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
124 |         libc::RLIMIT_RSS => Resource::Rss,
    |         ^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:125:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
125 |         libc::RLIMIT_NPROC => Resource::Nproc,
    |         ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:126:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
126 |         libc::RLIMIT_NOFILE => Resource::Nofile,
    |         ^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:127:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
127 |         libc::RLIMIT_MEMLOCK => Resource::Memlock,
    |         ^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:128:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
128 |         libc::RLIMIT_AS => Resource::As,
    |         ^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:129:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
129 |         libc::RLIMIT_LOCKS => Resource::Locks,
    |         ^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:130:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
130 |         libc::RLIMIT_SIGPENDING => Resource::Sigpending,
    |         ^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:131:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
131 |         libc::RLIMIT_MSGQUEUE => Resource::Msgqueue,
    |         ^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:132:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
132 |         libc::RLIMIT_NICE => Resource::Nice,
    |         ^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:133:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
133 |         libc::RLIMIT_RTPRIO => Resource::Rtprio,
    |         ^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/process/rlimit.rs:134:9
    |
118 |     Some(match resource {
    |                -------- this expression has type `u32`
...
134 |         libc::RLIMIT_RTTIME => Resource::Rttime,
    |         ^^^^^^^^^^^^^^^^^^^ expected `u32`, found `i32`

error[E0609]: no field `c_ispeed` on type `&libc::termios`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/termios_/mod.rs:170:36
    |
170 |     result.set_input_speed(termios.c_ispeed).unwrap();
    |                                    ^^^^^^^^ help: a field with a similar name exists: `__c_ispeed`

error[E0609]: no field `c_ospeed` on type `&libc::termios`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/termios_/mod.rs:171:37
    |
171 |     result.set_output_speed(termios.c_ospeed).unwrap();
    |                                     ^^^^^^^^ help: a field with a similar name exists: `__c_ospeed`

error[E0560]: struct `libc::termios` has no field named `c_ispeed`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/termios_/mod.rs:194:9
    |
194 |         c_ispeed: to_libc_speed(termios.input_speed()),
    |         ^^^^^^^^ help: a field with a similar name exists: `__c_ispeed`

error[E0560]: struct `libc::termios` has no field named `c_ospeed`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/termios_/mod.rs:195:9
    |
195 |         c_ospeed: to_libc_speed(termios.output_speed()),
    |         ^^^^^^^^ help: a field with a similar name exists: `__c_ospeed`

error[E0061]: this method takes 1 argument but 0 arguments were supplied
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:57:63
   |
57 |     let ValueWithEpoch { epoch, data } = VALUES[key as usize].get();
   |                                                               ^^^-- an argument is missing
   |
note: method defined here
  --> /rustc/df871fbf053de3a855398964cd05fadbe91cf4fd/library/core/src/slice/mod.rs:601:12
help: provide the argument
   |
57 |     let ValueWithEpoch { epoch, data } = VALUES[key as usize].get(/* index */);
   |                                                                  ~~~~~~~~~~~~~

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/key.rs:57:9
   |
57 |     let ValueWithEpoch { epoch, data } = VALUES[key as usize].get();
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   -------------------------- this expression has type `Option<&_>`
   |         |
   |         expected `Option<&_>`, found `ValueWithEpoch`
   |
   = note: expected enum `Option<&_>`
            found struct `ValueWithEpoch`

error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/use_libc.rs:22:17
    |
22  |                 core::mem::transmute(crate::use_libc::Pad::new(core::ptr::read(src_ptr)));
    |                 ^^^^^^^^^^^^^^^^^^^^
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/thread/mod.rs:535:9
    |
535 |         checked_cast!(rwlockattr)
    |         ------------------------- in this macro invocation
    |
    = note: source type: `Pad<PthreadRwlockattrT>` (128 bits)
    = note: target type: `Pad<pthread_rwlockattr_t>` (96 bits)
    = note: this error originates in the macro `checked_cast` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/c-scape-0.15.13/src/time/mod.rs:68:33
    |
68  |     libc!(libc::gettimeofday(t, _tz));
    |           ------------------    ^^^ expected `*mut c_void`, found `*mut timezone`
    |           |
    |           arguments to this function are incorrect
    |
    = note: expected raw pointer `*mut c_void`
               found raw pointer `*mut timezone`
note: function defined here
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.149/src/unix/linux_like/linux/musl/mod.rs:737:12
    |
737 |     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
    |            ^^^^^^^^^^^^

Some errors have detailed explanations: E0061, E0308, E0425, E0512, E0560, E0609.
For more information about an error, try `rustc --explain E0061`.
error: could not compile `c-scape` (lib) due to 52 previous errors
warning: build failed, waiting for other jobs to finish...
```